### PR TITLE
Implementation of bowling score calculator in Python 3

### DIFF
--- a/bowling_calc.py
+++ b/bowling_calc.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python3
+
+MAX_FRAMES = 10
+def score(line):
+  # Keep track of how many rolls have been taken
+  roll = 0
+  # How many points have been collected so far
+  total = 0
+  # Calculate how many points each roll is worth, so we can easily figure out how many points spares and strikes are worth.
+  rollScores = list(map(pointValue, line))
+
+  for frame in range(MAX_FRAMES):
+    if line[roll] == "X":
+      # Collect points for this roll, plus two future rolls. The extra +1 is because the interval is open on the right.
+      total += sum(rollScores[roll:roll+2 + 1])
+      roll += 1
+    else:
+      # Not a strike, so make two attempts and count up the points.
+      thisFrameScore = 0
+      for attempt in range(2):
+        if line[roll].isnumeric() or line[roll] == "-":
+          # Earn additional points for number of pins knocked down.
+          thisFrameScore += rollScores[roll]
+        elif line[roll] == "/":
+          # Collect points for this roll, plus the next one. Previously accumulated points are discarded.
+          thisFrameScore = sum(rollScores[roll:roll+1 + 1])
+        roll += 1
+      total += thisFrameScore
+    
+  return total
+
+def pointValue(mark):
+  if mark == "X": return 10
+  if mark == "/": return 10
+  if mark == "-": return 0
+  if mark.isnumeric(): return int(mark, 10)
+  raise RuntimeError("Invalid mark")

--- a/test-cases.py
+++ b/test-cases.py
@@ -1,0 +1,19 @@
+#! /usr/bin/env python3
+
+from bowling_calc import score
+import unittest
+
+class BowlingTests(unittest.TestCase):
+  def test_strikes(self):
+    self.assertEqual(score('XXXXXXXXXXXX'), 300)
+  def test_scores(self):
+    self.assertEqual(score('9-9-9-9-9-9-9-9-9-9-'), 90)
+  def test_spares(self):
+    self.assertEqual(score('5/5/5/5/5/5/5/5/5/5/5'), 150)
+  def test_no_extra_point(self):
+    self.assertEqual(score('5/------------------'), 10)
+  def test_nearly_all_strikes(self):
+    self.assertEqual(score('XXXXXXXXXX--'), 270)
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Run test cases with "python3 test-cases.py".

Program comments: Instead of attempting to track future rolls, pre-calculate the value of each roll up front, and whenever a future roll value is needed, get it from the pre-calculated list. This would be undesirable if we had a large number of rolls to calculate, since it would use a large amount of memory, but bowling only uses a maximum of twenty-one rolls per game (two per frame, except the last, which can be as many as one strike plus two bonus rolls or a roll, a spare, and one bonus roll for a total of three).

If this algorithm were to be applied to a large data set, one could use a bounded cache to store point values for each roll, and use essentially the same main loop to accumulate scores.
